### PR TITLE
#1 Heading font size bigger

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -76,6 +76,7 @@ h3 {
 header {
   background: #2F3061;
   color: #F7FFF7;
+  font-size: 1.3rem;
 }
 
 


### PR DESCRIPTION
Heading font size has been changed to 1.3rem.
![image](https://user-images.githubusercontent.com/61143804/74818613-440c0d00-52ff-11ea-811e-d652f9cd3ee0.png)
